### PR TITLE
Output dir is now cached across app launches

### DIFF
--- a/app/src/main/java/com/npes87184/s2tdroid/donate/model/KeyCollection.java
+++ b/app/src/main/java/com/npes87184/s2tdroid/donate/model/KeyCollection.java
@@ -18,5 +18,6 @@ public class KeyCollection {
     public static final String KEY_SDCARD_URI = "sdcard_uri";
     public static final String KEY_DELETE_SOURCE = "delete_source";
     public static final String KEY_FILE_SORT = "file_sort";
+    public static final String KEY_OUTPUT_DIR_URI = "output_dir_uri";
 
 }


### PR DESCRIPTION
## Fix for issue #11 
- Included a new prefs key in `KeyCollection.java` to store chosen output dir path
- On choosing output dir for the first time round
  - The `Uri` is stored in prefs against the :point_up: key
  - Since `Uri`s perish once the activity is destroyed _(nice read [here](https://commonsware.com/blog/2016/08/10/uri-access-lifetime-shorter-than-you-might-think.html))_, `takePersistableUriPermission()` for this chosen `outputDirUri`
- Added a new method `readOutputDirUriFromCache()` that does `Uri.parse(...Uri string from prefs...)` to get the `Uri` back (basically _"uncaches"_ it back)
- All `outputDirUri` null checks have been enhanced with also checking if the "uncached" `Uri` from :point_up: also is null